### PR TITLE
fix(cli): improve scan subcommand help text

### DIFF
--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -77,5 +77,6 @@ def cli(ctx: click.Context) -> None:
 cli.add_command(cmd=ci)
 cli.add_command(cmd=login)
 cli.add_command(cmd=publish)
-cli.add_command(cmd=scan)
+cli.add_command(cmd=scan, name="scan")
+cli.commands["scan"].help = "Scan code using Semgrep rules (local, remote, or auto). Default command if none is given."
 cli.add_command(cmd=install_semgrep_pro)


### PR DESCRIPTION
Updated the CLI help description for the `scan` subcommand.

**Old:**
Run Semgrep rules on local folders or files

**New:**
Scan code using Semgrep rules (local, remote, or auto). Default command if none is given.

Clarifies default behavior and rule source flexibility. Improves usability for new users and aligns with actual Semgrep capabilities.

